### PR TITLE
Hotfix: 판매/구매 중인 상품 조회 API가 imageId 대신 image를 반환

### DIFF
--- a/src/service/product.service.ts
+++ b/src/service/product.service.ts
@@ -191,8 +191,13 @@ export default class ProductService {
     }
   }
 
-  static async getSellingProductsByUserId(userId: number): Promise<Product[]> {
+  static async getSellingProductsByUserId(
+    userId: number,
+    page: number,
+    limit: number,
+  ): Promise<Product[]> {
     try {
+      const skip = (page - 1) * limit;
       return await ProductRepository.find({
         where: {
           user: {
@@ -201,6 +206,8 @@ export default class ProductService {
           status: 'progress',
         },
         relations: ['user', 'department', 'image'],
+        skip: skip,
+        take: limit,
       });
     } catch (error) {
       throw new InternalServerError(

--- a/swagger.js
+++ b/swagger.js
@@ -97,7 +97,10 @@ const doc = {
         $status: 'progress',
         $currentHighestPrice: 5000,
         $upperBound: 10000,
-        $imageId: 1,
+        $image: {
+          $id: 1,
+          $url: 'cat.jpg',
+        },
         $departmentId: 1,
         $createdAt: '2024-01-04T00:00:00.000Z',
         $updatedAt: '2024-01-04T00:00:00.000Z',
@@ -110,7 +113,10 @@ const doc = {
           $status: 'progress',
           $user_highest_price: 35000,
           $upper_bound: 50000,
-          $image_id: 1,
+          $image: {
+            $id: 1,
+            $url: 'cat.jpg',
+          },
           $department_id: 1,
           $created_at: '2024-01-10T07:10:11.684Z',
           $updated_at: '2024-01-10T07:10:11.684Z',


### PR DESCRIPTION
## 작업 내용
- `imageId` 대신 `image` 반환
- 페이징 지원 ex: `GET /users/current-user/product/sell?page=1&pageSize=4`