### PR TITLE
Hotfix: 학과별 상품 검색 지원

### DIFF
--- a/src/controller/product/controller.ts
+++ b/src/controller/product/controller.ts
@@ -176,7 +176,7 @@ export const getProducts: RequestHandler = async (req, res, next) => {
     in: 'query',                                     
     required: false,                     
     type: "number",
-    description: 'sort=popular일 때만 사용 가능. ex) sort=popular&departmentId=49: 컴퓨터학과 소속 입찰자가 많은 순으로',                       
+    description: 'sort=popular일 때와 아닐 때의 동작이 다른 것에 주의 ex) sort=popular&departmentId=49: 컴퓨터학과 소속 입찰자가 많은 순으로, ex) sort=recent&departmentId=49: 컴퓨터학과 상품들을 최근 순으로'
   };
   #swagger.parameters['page'] = {
     in: 'query',                                     
@@ -219,6 +219,8 @@ export const getProducts: RequestHandler = async (req, res, next) => {
         isRecentOrdered: sort === 'recent',
         page: Number(page) > 0 ? Number(page) : undefined,
         limit: Number(pageSize) > 0 ? Number(pageSize) : undefined,
+        departmentId:
+          Number(departmentId) > 0 ? Number(departmentId) : undefined,
       });
     }
 

--- a/src/service/product.service.ts
+++ b/src/service/product.service.ts
@@ -62,6 +62,7 @@ export default class ProductService {
   ): Promise<Product | null> {
     try {
       const image = await ImageService.getImageById(updateProductDTO.imageId);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { imageId, ...withoutImageId } = updateProductDTO;
       const updateProductDAO = {
         ...withoutImageId,
@@ -103,14 +104,18 @@ export default class ProductService {
 
   static async getProducts(option: GetProductsOption): Promise<Product[]> {
     try {
-      const { search, isRecentOrdered, page, limit } = option;
+      const { search, isRecentOrdered, page, limit, departmentId } = option;
       const skip =
         page !== undefined && limit !== undefined
           ? (page - 1) * limit
           : undefined;
 
       return await ProductRepository.find({
-        where: search ? { productName: Like(`%${search}%`) } : undefined,
+        // where: search ? { productName: Like(`%${search}%`) } : undefined,
+        where: {
+          productName: search ? Like(`%${search}%`) : undefined,
+          department: departmentId ? { id: departmentId } : undefined,
+        },
         relations: ['user', 'department', 'image'],
         skip: skip,
         take: limit,

--- a/src/type/product/get.products.option.ts
+++ b/src/type/product/get.products.option.ts
@@ -3,6 +3,7 @@ export interface GetProductsOption {
   isRecentOrdered?: boolean;
   page?: number;
   limit?: number;
+  departmentId?: number;
 }
 
 export interface GetPopularProductsOption {


### PR DESCRIPTION
`GET /products`에서 `departmentId` 쿼리를 써서 특정 학과의 상품 검색 가능